### PR TITLE
Fix UB/exception in lwtr_example

### DIFF
--- a/example/lwtr_example.cpp
+++ b/example/lwtr_example.cpp
@@ -101,7 +101,7 @@ public:
     , read_gen("read", pipelined_stream, "addr", "data")
     , write_gen("write", pipelined_stream, "wr")
     , addr_gen("addr", addr_stream, "addr")
-    , rdata_gen("rdata", data_stream, nullptr, "data")
+    , rdata_gen("rdata", data_stream, "", "data")
     , wdata_gen("wdata", data_stream, "data") {}
     data_t read(const addr_t* p_addr) override;
     void write(const write_t* req) override;


### PR DESCRIPTION
Constructing std::string from nullptr is UB, throws exception in debug build.