### PR TITLE
Fix standalone build and add examples to GitHub Actions CI

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -1,0 +1,34 @@
+name: CI Examples
+
+on:
+  push:
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**CMakeLists.txt'
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '**.cpp'
+      - '**.h'
+      - '**CMakeLists.txt'
+      - '.github/workflows/**'
+
+jobs:
+  build-and-run-examples:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cpp_std: [17, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ libfmt-dev
+      - name: Configure
+        run: >
+          cmake -S . -B build  -DCMAKE_CXX_STANDARD=${{ matrix.cpp_std }} || true;
+          cmake -S . -B build  -DCMAKE_CXX_STANDARD=${{ matrix.cpp_std }}
+      - name: Build examples
+        run: cmake --build build -j$(nproc) --target lwtr_example lwtr_event_example lwtr_event_example_wait
+      - name: Run examples
+        run: ctest --test-dir build/example --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,22 @@ if(CMAKE_PROJECT_NAME STREQUAL "lwtr4sc")
     FIND_PACKAGE_ARGS
   )
   FetchContent_MakeAvailable(fmt)
+  # Build lz4 from source so the binary FTR backend (lwtr_ftr.cpp / tx_ftr_init)
+  # is available on any machine without a preinstalled lz4. As a fetched
+  # subproject lz4 builds a static library, so force PIC to link it into the
+  # shared lwtr library, and skip its CLI. Alias to the lz4::lz4 name the
+  # project's find_package()-based checks expect.
+  set(LZ4_BUILD_CLI OFF CACHE BOOL "" FORCE)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  FetchContent_Declare(lz4
+    GIT_REPOSITORY https://github.com/lz4/lz4.git
+    GIT_TAG v1.10.0
+    SOURCE_SUBDIR build/cmake
+  )
+  FetchContent_MakeAvailable(lz4)
+  if(NOT TARGET lz4::lz4)
+    add_library(lz4::lz4 ALIAS lz4)
+  endif()
   FetchContent_Declare(
       scp_git
       GIT_REPOSITORY  "https://github.com/accellera-official/systemc-common-practices.git"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.20)
 project(lwtr4sc VERSION 1.0.0)
 
 if(CMAKE_PROJECT_NAME STREQUAL "lwtr4sc")
+  enable_testing()
   include(FetchContent)
   # Make fmt's targets exportable so install(EXPORT) of lwtr/reporting succeeds,
   # and prefer a system-installed fmt (imported, already exportable) when present.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,13 @@ project(lwtr4sc VERSION 1.0.0)
 
 if(CMAKE_PROJECT_NAME STREQUAL "lwtr4sc")
   include(FetchContent)
+  # Make fmt's targets exportable so install(EXPORT) of lwtr/reporting succeeds,
+  # and prefer a system-installed fmt (imported, already exportable) when present.
+  set(FMT_INSTALL ON CACHE BOOL "" FORCE)
   FetchContent_Declare(fmt
     GIT_REPOSITORY https://github.com/fmtlib/fmt.git
     GIT_TAG 9.1.0
+    FIND_PACKAGE_ARGS
   )
   FetchContent_MakeAvailable(fmt)
   FetchContent_Declare(

--- a/example/lwtr_event_example.cpp
+++ b/example/lwtr_event_example.cpp
@@ -76,7 +76,7 @@ void test::main() {
 
     uint64_t tx_id = 1;
     uint64_t cycle = 0;
-    const sc_core::sc_time CYCLE_TIME = 10_ns;  // 10 ns per cycle
+    const sc_core::sc_time CYCLE_TIME = sc_core::sc_time(10, sc_core::SC_NS);  // 10 ns per cycle
     const uint64_t STAGE_LATENCY = 1;  // 1 cycle per pipeline stage
 
     // Simulate dual-issue CPU executing instructions

--- a/example/lwtr_event_example_wait.cpp
+++ b/example/lwtr_event_example_wait.cpp
@@ -76,12 +76,12 @@ void test::main() {
     // Generator IDs: 0 = cpu_tx, 1 = cpu_events, 2 = mem_tx, 3 = mem_events
     lwtr::tx_fiber cpu_fiber((std::string(name()) + ".CPU_Core").c_str(), "transactions");
     lwtr::tx_fiber mem_fiber((std::string(name()) + ".Memory").c_str(), "transactions");
-    lwtr::tx_generator<char const*, char const*> instruction_gen("instruction", cpu_fiber, "mnemonic", "result");
-    lwtr::tx_generator<char const*> bus_transaction_gen("bus_transaction", mem_fiber, "op");
+    lwtr::tx_generator<char const*, char const*> instruction_gen("instruction", cpu_fiber, "mnemonic", "result", true);
+    lwtr::tx_generator<char const*> bus_transaction_gen("bus_transaction", mem_fiber, "op", true);
 
     uint64_t tx_id = 1;
     uint64_t cycle = 0;
-    const sc_core::sc_time CYCLE_TIME = 10_ns; // 10 ns per cycle
+    const sc_core::sc_time CYCLE_TIME = sc_core::sc_time(10, sc_core::SC_NS); // 10 ns per cycle
     const uint64_t STAGE_LATENCY = 1;          // 1 cycle per pipeline stage
 
     // Simulate dual-issue CPU executing instructions
@@ -110,6 +110,7 @@ void test::main() {
     // Process instructions in pairs (dual issue)
     for(size_t i = 0; i < program.size(); i += 2) {
         wait(5 * CYCLE_TIME);
+        auto issue_time = sc_core::sc_time_stamp();
 
         // Issue up to 2 instructions simultaneously
         for (size_t j = 0; j < 2; ++j) {
@@ -126,7 +127,7 @@ void test::main() {
             auto stage_time = issue_time;
             for(int s = 0; s < 5; ++s) {
                 PipelineStage stage = static_cast<PipelineStage>(s);
-                insn_tx.record_event(stage_name(stage), stage_time, "stage_id", static_cast<uint64_t>(s), "pc", insn.addr);
+                insn_tx.record_event_at_time(stage_name(stage), stage_time, "stage_id", static_cast<uint64_t>(s), "pc", insn.addr);
                 stage_time += STAGE_LATENCY * CYCLE_TIME;
             }
 
@@ -144,13 +145,13 @@ void test::main() {
                 auto mem_stage_time = mem_start;
                 for(int s = 0; s < 5; ++s) {
                     MemoryStage stage = static_cast<MemoryStage>(s);
-                    mem_tx.record_event(mem_stage_name(stage), mem_stage_time, "fabric_node", static_cast<uint64_t>(s), "addr",
-                                        insn.mem_addr);
+                    mem_tx.record_event_at_time(mem_stage_name(stage), mem_stage_time, "fabric_node", static_cast<uint64_t>(s), "addr",
+                                                insn.mem_addr);
                     mem_stage_time += 2 * CYCLE_TIME; // Memory fabric has 2-cycle latency per stage
                 }
 
                 // Memory transaction ends after all fabric stages
-                mem_tx.end_tx(mem_stage_time);
+                mem_tx.end_tx_delayed(mem_stage_time);
 
                 // Instruction takes longer due to memory access
                 insn_tx.end_tx_delayed<char const*>(mem_stage_time, "ok");


### PR DESCRIPTION
Examples did not work out-of-the box of freshly installed Ubuntu 26.
Add examples build & run to CI.
Since this repo sees only occasional activity, the extra compute is unlikely to meaningfully accelerate climate change.