### PR TITLE
fix(lwtr): record the event name passed to record_event

### DIFF
--- a/src/lwtr/lwtr.cpp
+++ b/src/lwtr/lwtr.cpp
@@ -141,7 +141,7 @@ tx_generator_base::tx_generator_base(std::string  name, tx_fiber& fiber, std::st
     for(auto& e : impl::cb)
         e.second(*this, CREATE);
     if(with_events) {
-        auto gen = new tx_generator_base(generator_name+".events", fiber);
+        auto gen = new tx_generator_base(generator_name+".events", fiber, "name");
         evt_gen.reset(gen);
         evt_rel = get_tx_fiber().get_tx_db()->create_relation("parent_of");
     }

--- a/src/lwtr/lwtr.h
+++ b/src/lwtr/lwtr.h
@@ -373,7 +373,7 @@ public:
     void record_event(const char* name, NameValues&&... nvs) {
         auto& evt_gen = get_tx_generator_base().get_evt_gen();
         if(evt_gen) {
-            auto evt_hndl = evt_gen->begin_tx(value(), sc_core::sc_time_stamp(), get_tx_generator_base().get_evt_rel(), this);
+            auto evt_hndl = evt_gen->begin_tx(name ? value(name) : value(), sc_core::sc_time_stamp(), get_tx_generator_base().get_evt_rel(), this);
             record_event_attrs(evt_hndl, std::forward<NameValues>(nvs)...);
             evt_hndl.end_tx();
         }
@@ -383,7 +383,7 @@ public:
     void record_event_at_time(const char* name, sc_core::sc_time timestamp, NameValues&&... nvs) {
         auto& evt_gen = get_tx_generator_base().get_evt_gen();
         if(evt_gen) {
-            auto evt_hndl = evt_gen->begin_tx(value(), timestamp, get_tx_generator_base().get_evt_rel(), this);
+            auto evt_hndl = evt_gen->begin_tx(name ? value(name) : value(), timestamp, get_tx_generator_base().get_evt_rel(), this);
             record_event_attrs(evt_hndl, std::forward<NameValues>(nvs)...);
             evt_hndl.end_tx();
         }


### PR DESCRIPTION
tx_handle::record_event and record_event_at_time took the event name as their first parameter but never used it: the event transaction was begun with an empty value() and the ".events" generator was constructed without a begin attribute name, so every event written through this API ended up anonymous in the trace. 

The shipped examples clearly expect the names (pipeline stages "IF", "ID", ...) to be recorded.

And logically each event should at least have name and timestamp.