### PR TITLE
fix(lwtr-ftr): use the source transaction's fiber for relation stream id

### DIFF
--- a/src/lwtr/lwtr_ftr.cpp
+++ b/src/lwtr/lwtr_ftr.cpp
@@ -203,7 +203,7 @@ template <typename DB> void tx_handle_relation_cbf(const tx_handle& tr_1, const 
     if(f_1.get_tx_db()->get_recording() == false)
         return;
     if(Writer<DB>::get().is_open()) {
-        auto const& f_2 = tr_1.get_tx_fiber();
+        auto const& f_2 = tr_2.get_tx_fiber();
         Writer<DB>::writer().writeRelation(f_1.get_tx_db()->get_relation_name(relation_handle), f_1.get_id(), tr_1.get_id(), f_2.get_id(),
                                            tr_2.get_id());
     }


### PR DESCRIPTION
Looks like typo.

Same-fiber relations were unaffected because both fibers coincide, but cross-fiber relations - such as the instruction-to-bus parent_of link in lwtr_event_example - were written with the wrong source stream id.